### PR TITLE
fix(window-button): compatibility with FF 71

### DIFF
--- a/theme/parts/csd.css
+++ b/theme/parts/csd.css
@@ -45,7 +45,8 @@
 	padding: 0 3px 0 4px;
 	position: absolute !important;	
 	right: 0;
-	top: 0;	
+	top: 0;
+	display: block !important;
 }
 :root[tabsintitlebar] #titlebar .titlebar-buttonbox {
 	-moz-appearance: none !important;


### PR DESCRIPTION
https://github.com/rafaelmardojai/firefox-gnome-theme/commit/600ed1e3da108f6190d678cf18d151a63787a590

Ref: https://github.com/rafaelmardojai/firefox-gnome-theme/issues/85

Before:

![before](https://user-images.githubusercontent.com/43627182/70706786-92f95d00-1d26-11ea-8610-7e573731ec79.png)

After:

![after](https://user-images.githubusercontent.com/43627182/70706796-9987d480-1d26-11ea-840e-76c0af66e043.png)

