### PR TITLE
fix(csd): top margin of window buttons FF74

### DIFF
--- a/theme/parts/csd.css
+++ b/theme/parts/csd.css
@@ -59,7 +59,7 @@
 	border-color: transparent !important;
 	border-radius: 5px !important;
 	height: 30px;
-	margin: -8px -2px !important;
+	margin: 4px -2px !important;
 	padding: 0 2px !important;
 	width: 30px;
 }


### PR DESCRIPTION
Noticed this issue after upgrade to v74.

Before:
![before](https://user-images.githubusercontent.com/43627182/76697642-8ac80980-66e9-11ea-9893-8c89e25f7e78.png)

After:
![after](https://user-images.githubusercontent.com/43627182/76697649-91568100-66e9-11ea-8ca4-0a894a22244a.png)
