### PR TITLE
Error handling, shellcheck, and shellfmt.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,55 +1,84 @@
 #!/bin/bash
 
-THEMEDIRECTORY=$(cd `dirname $0` && cd .. && pwd)
-FIREFOXFOLDER=~/.mozilla/firefox/
+THEMEDIRECTORY=$(cd "$(dirname "$0")" && cd ../ && pwd)
+FIREFOXFOLDER="$HOME/.mozilla/firefox"
 PROFILENAME=""
 GNOMISHEXTRAS=false
 
 # Get options.
 while getopts 'f:p:g' flag; do
-	case "${flag}" in    
-		f) FIREFOXFOLDER="${OPTARG}" ;;
-		p) PROFILENAME="${OPTARG}" ;;
-		g) GNOMISHEXTRAS=true ;;
+	case "${flag}" in
+	f) FIREFOXFOLDER="${OPTARG}" ;;
+	p) PROFILENAME="${OPTARG}" ;;
+	g) GNOMISHEXTRAS=true ;;
+	*) echo "Incorrect flag used" && exit 1 ;;
 	esac
 done
 
 # Define profile folder path.
-if test -z "$PROFILENAME" 
-	then
-		PROFILEFOLDER="$FIREFOXFOLDER/*.default"
+if test -z "$PROFILENAME"; then
+	pattern="$FIREFOXFOLDER/*.default*"
+
+	# Tried to use mapfile and read -a, but didn't get desired results. Disabling shellcheck on this one.
+	# shellcheck disable=SC2206
+	files=($pattern)
+
+	if [ -d "${files[0]}" ]; then
+		PROFILEFOLDER="${files[0]}"
 	else
+		echo "${files[0]} detected as firefox profile, but the directory wasn't found." && exit 1
+	fi
+else
+	if [ -d "$FIREFOXFOLDER/$PROFILENAME" ]; then
 		PROFILEFOLDER="$FIREFOXFOLDER/$PROFILENAME"
+	else
+		echo "$FIREFOXFOLDER/$PROFILENAME was not found." && exit 1
+	fi
 fi
 
 # Enter Firefox profile folder.
-cd $PROFILEFOLDER
-echo "Installing theme in $PWD"
+if cd "$PROFILEFOLDER"; then
+	echo "Installing theme in $PWD"
+else
+	echo "We could not enter ${PROFILEFOLDER}. Exiting." && exit 1
+fi
 
 # Create a chrome directory if it doesn't exist.
-mkdir -p chrome
-cd chrome
+mkdir -p ./chrome || {
+	echo "We could not create  ./chrome. Exiting."
+	exit 1
+}
+cd ./chrome || {
+	echo "We could not enter  ./chrome. Exiting."
+	exit 1
+}
 
 # Copy theme repo inside
-echo "Coping repo in $PWD"
-cp -R $THEMEDIRECTORY $PWD
+echo "Copying files to $PWD"
+
+# If rsync is in $PATH, we should use that to avoid copying entire git repos into our theme folder
+if [ -x "$(command -v rsync)" ]; then
+	rsync -aq --progress "$THEMEDIRECTORY" "$PWD" --exclude ".git"
+else
+	cp -R "$THEMEDIRECTORY" "$PWD"
+fi
 
 # Create single-line user CSS files if non-existent or empty.
-[[ -s userChrome.css ]] || echo >> userChrome.css
+[[ -s userChrome.css ]] || echo >>userChrome.css
 
 # Import this theme at the beginning of the CSS files.
 sed -i '1s/^/@import "firefox-sweet-theme\/userChrome.css";\n/' userChrome.css
 
 # If GNOMISH extras enabled, import it in customChrome.css.
-if [ "$GNOMISHEXTRAS" = true ] ; then
+if [ "$GNOMISHEXTRAS" = true ]; then
 	echo "Enabling GNOMISH extra features"
-    [[ -s customChrome.css ]] || echo >> firefox-sweet-theme/customChrome.css
+	[[ -s customChrome.css ]] || echo >>firefox-sweet-theme/customChrome.css
 	sed -i '1s/^/@import "theme\/hide-single-tab.css";\n/' firefox-sweet-theme/customChrome.css
 	sed -i '2s/^/@import "theme\/matching-autocomplete-width.css";\n/' firefox-sweet-theme/customChrome.css
 fi
 
 # Symlink user.js to firefox-sweet-theme one.
 echo "Set configuration user.js file"
-ln -s chrome/firefox-sweet-theme/configuration/user.js ../user.js
+ln -sf ./chrome/firefox-sweet-theme/configuration/user.js ../user.js
 
 echo "Done."


### PR DESCRIPTION
Main motivation for PR: My profile in firefox was something like $HOME/$FIREFOXFOLDER//le545tters.default-654654. Therefore, the detection of *.default in the install script was not working for me.

I fixed this by searching for all profiles containing ".default" and we use the first match we find. I also added more error handling and error messages. If someone feeds illegal/non-existing directories to -f or -p, no work is done and we exit early while informing the user. I forced the symlink at the end of the script, so we don't throw errors if symlink already exists. I also ran ShellCheck against the script and fixed everything I caught. Finally, I ran shellfmt on the script.