### PR TITLE
Fix script shebang compatiblitiy

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 THEMEDIRECTORY=$(cd `dirname $0` && cd .. && pwd)
 FIREFOXFOLDER=~/.mozilla/firefox/


### PR DESCRIPTION
Just a little shebang fix for making the script work on Nixos and other Unix systems that do not have bash installed on the default path.